### PR TITLE
[wip] JSON Patch Compactor

### DIFF
--- a/packages/patch/lib/compact.js
+++ b/packages/patch/lib/compact.js
@@ -1,6 +1,34 @@
 "use strict";
 
+function remove(operations = []) {
+  const cancellingOperation = operations.find(op => op[1] === "add");
+  if (cancellingOperation !== undefined) {
+    return cancellingOperation;
+  }
+
+  return null;
+}
+
 function compact(jsonPatch = []) {
+  const operations = {};
+
+  for (const i in jsonPatch) {
+    const { op, path, value } = jsonPatch[i];
+    if (operations[path] === undefined) {
+      operations[path] = [];
+    }
+
+    operations[path].push([i, op, value]);
+
+    if (op === "remove") {
+      const cancelling = remove(operations[path]);
+      if (cancelling) {
+        jsonPatch.splice(cancelling[0], 1);
+        jsonPatch.pop();
+      }
+    }
+  }
+
   return jsonPatch;
 }
 

--- a/packages/patch/lib/compact.js
+++ b/packages/patch/lib/compact.js
@@ -29,6 +29,15 @@ function replace(operations = []) {
   return null;
 }
 
+function copy(operations = []) {
+  const cancellingOperation = operations.find(op => /replace/.test(op[1]));
+  if (cancellingOperation !== undefined) {
+    return cancellingOperation;
+  }
+
+  return null;
+}
+
 function compact(jsonPatch = []) {
   const operations = {};
 
@@ -59,6 +68,13 @@ function compact(jsonPatch = []) {
     }
 
     if (op === "replace") {
+      const cancelling = replace(operations[path]);
+      if (cancelling && cancelling[2] !== value) {
+        jsonPatch.splice(cancelling[0], 1);
+      }
+    }
+
+    if (op === "copy") {
       const cancelling = replace(operations[path]);
       if (cancelling && cancelling[2] !== value) {
         jsonPatch.splice(cancelling[0], 1);

--- a/packages/patch/lib/compact.js
+++ b/packages/patch/lib/compact.js
@@ -9,6 +9,15 @@ function remove(operations = []) {
   return null;
 }
 
+function add(operations = []) {
+  const cancellingOperation = operations.find(op => op[1] === "remove");
+  if (cancellingOperation !== undefined) {
+    return cancellingOperation;
+  }
+
+  return null;
+}
+
 function compact(jsonPatch = []) {
   const operations = {};
 
@@ -22,6 +31,14 @@ function compact(jsonPatch = []) {
 
     if (op === "remove") {
       const cancelling = remove(operations[path]);
+      if (cancelling) {
+        jsonPatch.splice(cancelling[0], 1);
+        jsonPatch.pop();
+      }
+    }
+
+    if (op === "add") {
+      const cancelling = add(operations[path]);
       if (cancelling) {
         jsonPatch.splice(cancelling[0], 1);
         jsonPatch.pop();

--- a/packages/patch/lib/compact.js
+++ b/packages/patch/lib/compact.js
@@ -1,7 +1,9 @@
 "use strict";
 
 function remove(operations = []) {
-  const cancellingOperation = operations.find(op => op[1] === "add");
+  const cancellingOperation = operations.find(op =>
+    /add|replace|copy/.test(op[1])
+  );
   if (cancellingOperation !== undefined) {
     return cancellingOperation;
   }
@@ -11,6 +13,15 @@ function remove(operations = []) {
 
 function add(operations = []) {
   const cancellingOperation = operations.find(op => op[1] === "remove");
+  if (cancellingOperation !== undefined) {
+    return cancellingOperation;
+  }
+
+  return null;
+}
+
+function replace(operations = []) {
+  const cancellingOperation = operations.find(op => /replace|copy/.test(op[1]));
   if (cancellingOperation !== undefined) {
     return cancellingOperation;
   }
@@ -33,7 +44,9 @@ function compact(jsonPatch = []) {
       const cancelling = remove(operations[path]);
       if (cancelling) {
         jsonPatch.splice(cancelling[0], 1);
-        jsonPatch.pop();
+        if (cancelling[1] !== "replace") {
+          jsonPatch.pop();
+        }
       }
     }
 
@@ -42,6 +55,13 @@ function compact(jsonPatch = []) {
       if (cancelling) {
         jsonPatch.splice(cancelling[0], 1);
         jsonPatch.pop();
+      }
+    }
+
+    if (op === "replace") {
+      const cancelling = replace(operations[path]);
+      if (cancelling && cancelling[2] !== value) {
+        jsonPatch.splice(cancelling[0], 1);
       }
     }
   }

--- a/packages/patch/lib/compact.js
+++ b/packages/patch/lib/compact.js
@@ -1,7 +1,7 @@
 "use strict";
 
 function getCancellingOperation(operations = [], pattern = RegExp()) {
-  const cancellingOperation = operations.find(op => pattern.test(op[1]));
+  const cancellingOperation = operations.find(({ op }) => pattern.test(op));
   if (cancellingOperation !== undefined) {
     return cancellingOperation;
   }
@@ -11,11 +11,11 @@ function getCancellingOperation(operations = [], pattern = RegExp()) {
 
 const Cancelling = {
   remove: {
-    compact(operations = [], jsonPatch) {
+    compact(operations = [], jsonPatch = []) {
       const cancelling = getCancellingOperation(operations, /add|replace|copy/);
       if (cancelling) {
-        jsonPatch.splice(cancelling[0], 1);
-        if (cancelling[1] !== "replace") {
+        jsonPatch.splice(jsonPatch.indexOf(cancelling), 1);
+        if (cancelling.op !== "replace") {
           jsonPatch.pop();
         }
       }
@@ -25,50 +25,47 @@ const Cancelling = {
     compact(operations = [], jsonPatch) {
       const cancelling = getCancellingOperation(operations, /remove/);
       if (cancelling) {
-        jsonPatch.splice(cancelling[0], 1);
+        jsonPatch.splice(jsonPatch.indexOf(cancelling), 1);
         jsonPatch.pop();
       }
     },
   },
   replace: {
-    compact(operations = [], jsonPatch, value) {
+    compact(operations = [], jsonPatch, { value }) {
       const cancelling = getCancellingOperation(operations, /replace|copy/);
-      if (cancelling && cancelling[2] !== value) {
-        jsonPatch.splice(cancelling[0], 1);
+      if (cancelling && cancelling.value !== value) {
+        jsonPatch.splice(jsonPatch.indexOf(cancelling), 1);
       }
     },
   },
   copy: {
-    compact(operations = [], jsonPatch, value) {
+    compact(operations = [], jsonPatch, { value }) {
       const cancelling = getCancellingOperation(operations, /replace/);
-      if (cancelling && cancelling[2] !== value) {
-        jsonPatch.splice(cancelling[0], 1);
+      if (cancelling && cancelling.value !== value) {
+        jsonPatch.splice(jsonPatch.indexOf(cancelling), 1);
       }
     },
   },
-  move: {
-    compact() {},
-  },
-  test: {
-    compact() {},
-  },
+  move: { compact() {} },
+  test: { compact() {} },
 };
 
 function compact(jsonPatch = []) {
   const operations = {};
+  const auxPatch = [];
 
-  for (const i in jsonPatch) {
-    const { op, path, value } = jsonPatch[i];
+  jsonPatch.forEach(operation => {
+    const { op, path, value } = operation;
     if (operations[path] === undefined) {
       operations[path] = [];
     }
 
-    operations[path].push([i, op, value]);
+    operations[path].push(operation);
+    auxPatch.push(operation);
+    Cancelling[op].compact(operations[path], auxPatch, { value });
+  });
 
-    Cancelling[op].compact(operations[path], jsonPatch, value);
-  }
-
-  return jsonPatch;
+  return auxPatch;
 }
 
 module.exports = compact;

--- a/packages/patch/lib/compact.js
+++ b/packages/patch/lib/compact.js
@@ -1,0 +1,7 @@
+"use strict";
+
+function compact(jsonPatch = []) {
+  return jsonPatch;
+}
+
+module.exports = compact;

--- a/packages/patch/lib/compact.js
+++ b/packages/patch/lib/compact.js
@@ -1,5 +1,12 @@
 "use strict";
 
+/**
+ * Finds the operation to be cancelled given a regex pattern
+ * of the operation name, i.e. "add", "remove", etc.
+ * @param {array} operations An array with all operations made in a specific JSON pointer
+ * @param {regexp} pattern The regex pattern for operations that can be cancelled
+ * @returns {object} The cancelling operation or null if no operation matching the pattern is found
+ */
 function getCancellingOperation(operations = [], pattern = RegExp()) {
   const cancellingOperation = operations.find(({ op }) => pattern.test(op));
   if (cancellingOperation !== undefined) {
@@ -9,6 +16,12 @@ function getCancellingOperation(operations = [], pattern = RegExp()) {
   return null;
 }
 
+/**
+ * Removes the cancelling operation from the given JSON Patch array
+ *
+ * @param {*} jsonPatch The JSON Patch array from where to remove the cancelling operation
+ * @param {*} cancelling The cancelling object to be removed
+ */
 function removeCancellingOperation(jsonPatch = [], cancelling = {}) {
   jsonPatch.splice(jsonPatch.indexOf(cancelling), 1);
 }
@@ -19,6 +32,7 @@ const Cancelling = {
       const cancelling = getCancellingOperation(operations, /add|replace|copy/);
       if (cancelling) {
         removeCancellingOperation(jsonPatch, cancelling);
+        // if the cancelling operation is not "replace", then remove the current ("remove") operation as well
         if (cancelling.op !== "replace") {
           jsonPatch.pop();
         }
@@ -28,15 +42,16 @@ const Cancelling = {
   replace: {
     compact(operations = [], jsonPatch, { value }) {
       const cancelling = getCancellingOperation(operations, /replace|copy/);
+      // make sure the cancelling "replace" op is not the current operation
       if (cancelling && cancelling.value !== value) {
         removeCancellingOperation(jsonPatch, cancelling);
       }
     },
   },
   copy: {
-    compact(operations = [], jsonPatch, { value }) {
+    compact(operations = [], jsonPatch) {
       const cancelling = getCancellingOperation(operations, /replace/);
-      if (cancelling && cancelling.value !== value) {
+      if (cancelling) {
         removeCancellingOperation(jsonPatch, cancelling);
       }
     },
@@ -46,6 +61,24 @@ const Cancelling = {
   test: { compact() {} },
 };
 
+/**
+ * Compacts a JSON Patch removing all cancelling operations
+ * Ex.:
+ * [
+ *    { "op": "add", "path": "/foo", "value": "bar" },
+ *    { "op": "add", "path": "/bar", "value": "baz" },
+ *    { "op": "remove", "path": "/foo" }
+ * ]
+ *
+ * becomes:
+ * Ex.:
+ * [
+ *    { "op": "add", "path": "/bar", "value": "baz" },
+ * ]
+ *
+ * @param {Array} jsonPatch The JSON Patch to be compacted
+ * @returns {Array} The compacted JSON Patch
+ */
 function compact(jsonPatch = []) {
   const operations = {};
   const resultJsonPatch = [];
@@ -53,13 +86,17 @@ function compact(jsonPatch = []) {
   jsonPatch.forEach(operation => {
     const { op, path } = operation;
 
+    // creates an array of operations for each pointer
     if (operations[path] === undefined) {
       operations[path] = [];
     }
 
+    // stack operations on same pointer, for each pointer
     operations[path].push(operation);
+    // stores all operations in resultJsonPatch
     resultJsonPatch.push(operation);
 
+    // Call compact function for the current op inside the Cancelling object
     Cancelling[op].compact(operations[path], resultJsonPatch, operation);
   });
 

--- a/packages/patch/test/compact.js
+++ b/packages/patch/test/compact.js
@@ -1,0 +1,14 @@
+"use strict";
+
+const compact = require("../lib/compact");
+const tests = require("./compact.json");
+const assert = require("assert");
+
+describe("compact", () => {
+  tests.forEach(test => {
+    it(test.description, () => {
+      const result = compact(test.input);
+      assert.deepEqual(result, test.output);
+    });
+  });
+});

--- a/packages/patch/test/compact.json
+++ b/packages/patch/test/compact.json
@@ -1,0 +1,32 @@
+[
+  {
+    "description": "Returns the same object for add operation",
+    "input": [{ "op": "add", "path": "/foo", "value": "bar" }],
+    "output": [{ "op": "add", "path": "/foo", "value": "bar" }]
+  },
+  {
+    "description": "Returns the same object for remove operation",
+    "input": [{ "op": "remove", "path": "/foo", "value": "bar" }],
+    "output": [{ "op": "remove", "path": "/foo", "value": "bar" }]
+  },
+  {
+    "description": "Returns the same object for replace operation",
+    "input": [{ "op": "replace", "path": "/foo", "value": "bar" }],
+    "output": [{ "op": "replace", "path": "/foo", "value": "bar" }]
+  },
+  {
+    "description": "Returns the same object for move operation",
+    "input": [{ "op": "move", "path": "/foo", "value": "bar" }],
+    "output": [{ "op": "move", "path": "/foo", "value": "bar" }]
+  },
+  {
+    "description": "Returns the same object for copy operation",
+    "input": [{ "op": "copy", "path": "/foo", "value": "bar" }],
+    "output": [{ "op": "copy", "path": "/foo", "value": "bar" }]
+  },
+  {
+    "description": "Returns the same object for test operation",
+    "input": [{ "op": "test", "path": "/foo", "value": "bar" }],
+    "output": [{ "op": "test", "path": "/foo", "value": "bar" }]
+  }
+]

--- a/packages/patch/test/compact.json
+++ b/packages/patch/test/compact.json
@@ -79,5 +79,13 @@
       { "op": "replace", "path": "/foo", "value": "bar" }
     ],
     "output": [{ "op": "replace", "path": "/foo", "value": "bar" }]
+  },
+  {
+    "description": "Returns empty array, COPY cancelling REPLACE op",
+    "input": [
+      { "op": "replace", "path": "/foo", "value": "bar" },
+      { "op": "copy", "from": "/bar", "path": "/foo" }
+    ],
+    "output": [{ "op": "copy", "from": "/bar", "path": "/foo" }]
   }
 ]

--- a/packages/patch/test/compact.json
+++ b/packages/patch/test/compact.json
@@ -87,5 +87,21 @@
       { "op": "copy", "from": "/bar", "path": "/foo" }
     ],
     "output": [{ "op": "copy", "from": "/bar", "path": "/foo" }]
+  },
+  {
+    "description": "Should compact Patch with multiple cancelling operations",
+    "input": [
+      { "op": "add", "path": "/CEO", "value": "John" },
+      { "op": "add", "path": "/CFO", "value": "Anna" },
+      { "op": "add", "path": "/COO", "value": "Bruce" },
+      { "op": "replace", "path": "/CEO", "value": "Mike" },
+      { "op": "remove", "path": "/COO" },
+      { "op": "replace", "path": "/CEO", "value": "Beca" }
+    ],
+    "output": [
+      { "op": "add", "path": "/CEO", "value": "John" },
+      { "op": "add", "path": "/CFO", "value": "Anna" },
+      { "op": "replace", "path": "/CEO", "value": "Beca" }
+    ]
   }
 ]

--- a/packages/patch/test/compact.json
+++ b/packages/patch/test/compact.json
@@ -41,7 +41,7 @@
     ]
   },
   {
-    "description": "Returns empty array for canceling operations",
+    "description": "Returns empty array, REMOVE cancelling ADD op",
     "input": [
       { "op": "add", "path": "/foo", "value": "bar" },
       { "op": "remove", "path": "/foo" }
@@ -49,11 +49,35 @@
     "output": []
   },
   {
-    "description": "Returns empty array for canceling operations",
+    "description": "Returns empty array, REMOVE cancelling REPLACE op",
     "input": [
-      { "op": "remove", "path": "/foo" },
-      { "op": "add", "path": "/foo", "value": "bar" }
+      { "op": "replace", "path": "/foo", "value": "bar" },
+      { "op": "remove", "path": "/foo" }
+    ],
+    "output": [{ "op": "remove", "path": "/foo" }]
+  },
+  {
+    "description": "Returns empty array, REMOVE cancelling COPY op",
+    "input": [
+      { "op": "copy", "from": "/bar", "path": "/foo" },
+      { "op": "remove", "path": "/foo" }
     ],
     "output": []
+  },
+  {
+    "description": "Returns empty array, REPLACE cancelling REPLACE op",
+    "input": [
+      { "op": "replace", "path": "/foo", "value": "bar" },
+      { "op": "replace", "path": "/foo", "value": "baz" }
+    ],
+    "output": [{ "op": "replace", "path": "/foo", "value": "baz" }]
+  },
+  {
+    "description": "Returns empty array, REPLACE cancelling COPY op",
+    "input": [
+      { "op": "copy", "from": "/bar", "path": "/foo" },
+      { "op": "replace", "path": "/foo", "value": "bar" }
+    ],
+    "output": [{ "op": "replace", "path": "/foo", "value": "bar" }]
   }
 ]

--- a/packages/patch/test/compact.json
+++ b/packages/patch/test/compact.json
@@ -47,5 +47,13 @@
       { "op": "remove", "path": "/foo" }
     ],
     "output": []
+  },
+  {
+    "description": "Returns empty array for canceling operations",
+    "input": [
+      { "op": "remove", "path": "/foo" },
+      { "op": "add", "path": "/foo", "value": "bar" }
+    ],
+    "output": []
   }
 ]

--- a/packages/patch/test/compact.json
+++ b/packages/patch/test/compact.json
@@ -121,5 +121,14 @@
       { "op": "copy", "from": "/CFO", "path": "/CEO" },
       { "op": "replace", "path": "/CFO", "value": "Barbara" }
     ]
+  },
+  {
+    "description": "Should return correct JSON Patch for cancelling REMOVE op",
+    "input": [
+      { "op": "add", "path": "/foo", "value": "bar" },
+      { "op": "add", "path": "/bar", "value": "baz" },
+      { "op": "remove", "path": "/foo" }
+    ],
+    "output": [{ "op": "add", "path": "/bar", "value": "baz" }]
   }
 ]

--- a/packages/patch/test/compact.json
+++ b/packages/patch/test/compact.json
@@ -39,5 +39,13 @@
       { "op": "add", "path": "/foo", "value": "bar" },
       { "op": "add", "path": "/bar", "value": "baz" }
     ]
+  },
+  {
+    "description": "Returns empty array for canceling operations",
+    "input": [
+      { "op": "add", "path": "/foo", "value": "bar" },
+      { "op": "remove", "path": "/foo" }
+    ],
+    "output": []
   }
 ]

--- a/packages/patch/test/compact.json
+++ b/packages/patch/test/compact.json
@@ -103,5 +103,23 @@
       { "op": "add", "path": "/CFO", "value": "Anna" },
       { "op": "replace", "path": "/CEO", "value": "Beca" }
     ]
+  },
+  {
+    "description": "Should compact Patch with ADD, REPLACE, COPY and REMOVE ops",
+    "input": [
+      { "op": "add", "path": "/CEO", "value": "John" },
+      { "op": "add", "path": "/CFO", "value": "Anna" },
+      { "op": "add", "path": "/COO", "value": "Bruce" },
+      { "op": "replace", "path": "/CEO", "value": "Mike" },
+      { "op": "copy", "from": "/CFO", "path": "/CEO" },
+      { "op": "replace", "path": "/CFO", "value": "Barbara" },
+      { "op": "remove", "path": "/COO" }
+    ],
+    "output": [
+      { "op": "add", "path": "/CEO", "value": "John" },
+      { "op": "add", "path": "/CFO", "value": "Anna" },
+      { "op": "copy", "from": "/CFO", "path": "/CEO" },
+      { "op": "replace", "path": "/CFO", "value": "Barbara" }
+    ]
   }
 ]

--- a/packages/patch/test/compact.json
+++ b/packages/patch/test/compact.json
@@ -28,5 +28,16 @@
     "description": "Returns the same object for test operation",
     "input": [{ "op": "test", "path": "/foo", "value": "bar" }],
     "output": [{ "op": "test", "path": "/foo", "value": "bar" }]
+  },
+  {
+    "description": "Returns the same object for different multiple operations",
+    "input": [
+      { "op": "add", "path": "/foo", "value": "bar" },
+      { "op": "add", "path": "/bar", "value": "baz" }
+    ],
+    "output": [
+      { "op": "add", "path": "/foo", "value": "bar" },
+      { "op": "add", "path": "/bar", "value": "baz" }
+    ]
   }
 ]


### PR DESCRIPTION
This pull request propose an implementation of a JSON Patch compactor. The idea behind this feature is to remove all redundant operations in a JSON Patch, reducing it's overall size and also the number of operations to be performed.

The algorithm goes through each operation and creates a new object with an array of operations for each pointer. Then, for each key on this new operations object, it checks for cancelling operations and, if they exist, it removes them from the resulting json patch array.
Algorithm:

```
for each jsonpatch operation:
  operations[operation.path].push(operation)
  remove_cancelling_operations(operations[operation.path], resulting_json_patch)
end
return resulting_json_patch
```

This is a "work in progress" PR because it still need some work regarding arrays in the json patch.