### PR TITLE
pointer: fix prototype pollution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - "10"
   - "12"
   - "14"
+  - "15"
 
 matrix:
   fast_finish: true

--- a/packages/merge-patch/test/apply.js
+++ b/packages/merge-patch/test/apply.js
@@ -66,6 +66,7 @@ describe("apply", () => {
     );
 
     assert.equal(doc.isAdmin, undefined);
+    assert.equal({}.isAdmin, undefined);
     assert.equal("isAdmin" in doc, false);
   });
 });

--- a/packages/patch/lib/compile.js
+++ b/packages/patch/lib/compile.js
@@ -22,8 +22,6 @@ function pathToStatement(path) {
   return statement;
 }
 
-// "compile" lol https://github.com/bruth/jsonpatch-js/blob/master/jsonpatch.coffee#L377
-
 function compile(patch) {
   var code = "";
   patch.forEach(function (op) {

--- a/packages/patch/lib/walk.js
+++ b/packages/patch/lib/walk.js
@@ -20,12 +20,6 @@ module.exports = function walk(doc, tokens) {
   while (i < length - 1) {
     token = tokens[i++];
 
-    if (token === '__proto__' ||
-      (token == 'prototype' && i>1 && tokens[i-2] == 'constructor')
-    ) {
-      throw new Error("Prototype pollution attempt detected");
-    }
-
     if (Array.isArray(target)) validArrayToken(token, target.length);
     else if (typeof target !== OBJECT || target === null)
       throw new Error("Cannot be walked");

--- a/packages/patch/lib/walk.js
+++ b/packages/patch/lib/walk.js
@@ -20,6 +20,12 @@ module.exports = function walk(doc, tokens) {
   while (i < length - 1) {
     token = tokens[i++];
 
+    if (token === '__proto__' ||
+      (token == 'prototype' && i>1 && tokens[i-2] == 'constructor')
+    ) {
+      throw new Error("Prototype pollution attempt detected");
+    }
+
     if (Array.isArray(target)) validArrayToken(token, target.length);
     else if (typeof target !== OBJECT || target === null)
       throw new Error("Cannot be walked");

--- a/packages/patch/test/apply.js
+++ b/packages/patch/test/apply.js
@@ -1,0 +1,45 @@
+"use strict";
+
+const assert = require("assert").strict;
+const apply = require("../lib/apply");
+
+describe("apply", () => {
+  // https://github.com/HoLyVieR/prototype-pollution-nsec18
+  it("prevents prototype pollution", () => {
+    let doc = {};
+
+    assert.throws(
+      () => {
+        doc = apply(doc, [
+          {
+            op: "add",
+            path: "/__proto__/polluted",
+            value: "Yes! Its Polluted",
+          },
+        ]);
+      },
+      Error,
+      "Prototype pollution attempt"
+    );
+
+    assert.equal({}.polluted, undefined);
+    assert.equal(doc.polluted, undefined);
+
+    assert.throws(
+      () => {
+        doc = apply(doc, [
+          {
+            op: "add",
+            path: "/constructor/polluted",
+            value: "Yes! Its Polluted",
+          },
+        ]);
+      },
+      Error,
+      "Prototype pollution attempt"
+    );
+
+    assert.equal({}.polluted, undefined);
+    assert.equal(doc.polluted, undefined);
+  });
+});

--- a/packages/pointer/README.md
+++ b/packages/pointer/README.md
@@ -136,6 +136,12 @@ pointer.decode(".foo.bar.hello", ".");
 
 [↑](#json8-pointer)
 
+### prototype pollution
+
+`decode` will throw with an error if [prototype pollution](https://github.com/HoLyVieR/prototype-pollution-nsec18) is attempted.
+
+[↑](#json8-pointer)
+
 ### parse
 
 Alias for the [decode](#decode) method.

--- a/packages/pointer/lib/decode.js
+++ b/packages/pointer/lib/decode.js
@@ -17,6 +17,8 @@ module.exports = function decode(pointer, separator) {
 
   if (pointer.charAt(0) !== sep) throw new Error("Invalid pointer: " + pointer);
 
+  pointer = pointer.replace('__proto__'+sep, '').replace('constructor'+sep+'prototype'+sep,'');
+
   const tokens = [""];
   let c = 0;
 

--- a/packages/pointer/lib/decode.js
+++ b/packages/pointer/lib/decode.js
@@ -17,14 +17,16 @@ module.exports = function decode(pointer, separator) {
 
   if (pointer.charAt(0) !== sep) throw new Error("Invalid pointer: " + pointer);
 
-  pointer = pointer.replace('__proto__'+sep, '').replace('constructor'+sep+'prototype'+sep,'');
-
   const tokens = [""];
   let c = 0;
 
   for (let i = 1, len = pointer.length; i < len; i++) {
     const l = pointer.charAt(i);
     if (l === sep) {
+      const token = tokens[tokens.length - 1];
+      if (token === "constructor" || token === "__proto__") {
+        throw new Error("Prototype pollution attempt");
+      }
       tokens.push("");
       c++;
     } else if (l === "~") {

--- a/packages/pointer/test/token.js
+++ b/packages/pointer/test/token.js
@@ -3,7 +3,7 @@
 const assert = require("assert");
 const { encode, decode } = require("..");
 
-describe("parse", () => {
+describe("decode", () => {
   it("returns ['foo', 'bar']", () => {
     const r = decode("/foo/bar");
     assert.deepEqual(r, ["foo", "bar"]);
@@ -18,9 +18,28 @@ describe("parse", () => {
     const r = decode("");
     assert.deepEqual(r, []);
   });
+
+  // https://github.com/HoLyVieR/prototype-pollution-nsec18
+  it("prevents prototype pollution", () => {
+    assert.throws(
+      () => {
+        decode("/foo/constructor/bar");
+      },
+      Error,
+      "Prototype pollution attempt"
+    );
+
+    assert.throws(
+      () => {
+        decode("/foo/__proto__/bar");
+      },
+      Error,
+      "Prototype pollution attempt"
+    );
+  });
 });
 
-describe("serialize", () => {
+describe("encode", () => {
   it("should return /foo/bar", () => {
     const s = encode(["foo", "bar"]);
     assert.deepEqual(s, "/foo/bar");

--- a/packages/pointer/test/unflatten.js
+++ b/packages/pointer/test/unflatten.js
@@ -36,4 +36,31 @@ describe("unflatten", () => {
       assert.deepEqual(unflatten(flatten(json)), test);
     });
   });
+
+  // https://github.com/HoLyVieR/prototype-pollution-nsec18
+  it("prevents prototype pollution", () => {
+    assert.throws(
+      () => {
+        unflatten({
+          "": {},
+          "/firstName": "John",
+          "/__proto__/polluted": "Yes! Its Polluted",
+        });
+      },
+      Error,
+      "Prototype pollution attempt"
+    );
+
+    assert.throws(
+      () => {
+        unflatten({
+          "": {},
+          "/firstName": "John",
+          "/constructor/polluted": "Yes! Its Polluted",
+        });
+      },
+      Error,
+      "Prototype pollution attempt"
+    );
+  });
 });


### PR DESCRIPTION
```json8-patch``` and ```json8-pointer``` is vulnerable to prototype pollution.
POC
```json8-patch```
```javascript
var json8Patch = require("json8-patch")
var obj = {}
const patch = [{op: "add", path: "/__proto__/polluted", value: "Yes! Its Polluted"}];
console.log("Before : " + obj.polluted);
json8Patch.apply(obj, patch);
console.log("After : " + {}.polluted);
```

```json8-pointer```
```javascript
var json8Pointer = require("json8-pointer")
json8Pointer.unflatten({"": {},"/firstName": "John", "/__proto__/polluted": "Yes! Its Polluted"});
console.log({}.polluted)
```

OUTPUT
```
Before : undefined
After : Yes! Its Polluted
```
With this fix prototype pollution can be avoided. 