### PR TITLE
Add Date diff support

### DIFF
--- a/packages/json8/lib/equal.js
+++ b/packages/json8/lib/equal.js
@@ -2,6 +2,7 @@
 
 const types = require("./types");
 const OBJECT = types.OBJECT;
+const DATE = types.DATE;
 const ARRAY = types.ARRAY;
 const STRING = types.STRING;
 const BOOLEAN = types.BOOLEAN;
@@ -41,6 +42,8 @@ module.exports = function equal(a, b) {
     case NULL:
     case BOOLEAN:
       return a === b;
+    case DATE:
+      return a.getTime() === b.getTime();
   }
 
   let i, l;

--- a/packages/json8/lib/type.js
+++ b/packages/json8/lib/type.js
@@ -2,6 +2,7 @@
 
 const types = require("./types");
 const OBJECT = types.OBJECT;
+const DATE = types.DATE;
 const ARRAY = types.ARRAY;
 const NULL = types.NULL;
 const STRING = types.STRING;
@@ -18,6 +19,7 @@ module.exports = function type(obj) {
     else if (global.Set && obj instanceof Set) return ARRAY;
     else if (global.Map && obj instanceof Map) return OBJECT;
     else if (obj === null) return NULL;
+    else if (toString.call(obj) === '[object Date]') return DATE;
     else if (t === OBJECT) return OBJECT;
   }
 };

--- a/packages/json8/lib/type.js
+++ b/packages/json8/lib/type.js
@@ -19,7 +19,7 @@ module.exports = function type(obj) {
     else if (global.Set && obj instanceof Set) return ARRAY;
     else if (global.Map && obj instanceof Map) return OBJECT;
     else if (obj === null) return NULL;
-    else if (toString.call(obj) === '[object Date]') return DATE;
+    else if (toString.call(obj) === "[object Date]") return DATE;
     else if (t === OBJECT) return OBJECT;
   }
 };

--- a/packages/json8/lib/types.js
+++ b/packages/json8/lib/types.js
@@ -7,5 +7,6 @@ const STRING = (exports.STRING = "string");
 exports.PRIMITIVES = [NUMBER, BOOLEAN, NULL, STRING];
 
 const ARRAY = (exports.ARRAY = "array");
+const DATE = (exports.DATE = "date");
 const OBJECT = (exports.OBJECT = "object");
-exports.STRUCTURES = [ARRAY, OBJECT];
+exports.STRUCTURES = [ARRAY, DATE, OBJECT];

--- a/packages/json8/test/equal.js
+++ b/packages/json8/test/equal.js
@@ -62,8 +62,8 @@ describe("equal", () => {
 
     it("returns false for different", () => {
       differ(new Date(0), new Date(1));
-      differ(new Date(2021, 0, 1), new Date(2021, 0, 2))
-    })
+      differ(new Date(2021, 0, 1), new Date(2021, 0, 2));
+    });
   });
 
   describe("object", () => {

--- a/packages/json8/test/equal.js
+++ b/packages/json8/test/equal.js
@@ -54,6 +54,18 @@ describe("equal", () => {
     });
   });
 
+  describe("date", () => {
+    it("returns true for identical", () => {
+      equal(new Date(0), new Date(0));
+      equal(new Date(2021, 0, 1), new Date(2021, 0, 1));
+    });
+
+    it("returns false for different", () => {
+      differ(new Date(0), new Date(1));
+      differ(new Date(2021, 0, 1), new Date(2021, 0, 2))
+    })
+  });
+
   describe("object", () => {
     it("returns true for identical", () => {
       equal({ foo: "bar" }, { foo: "bar" });

--- a/packages/json8/test/type.js
+++ b/packages/json8/test/type.js
@@ -24,6 +24,10 @@ describe("type", () => {
     assert.strictEqual(type(null), "null");
   });
 
+  it("returns date for date", () => {
+    assert.strictEqual(type(new Date()), "date");
+  });
+
   it("returns object for object", () => {
     assert.strictEqual(type({}), "object");
   });

--- a/packages/json8/test/types.js
+++ b/packages/json8/test/types.js
@@ -24,6 +24,10 @@ describe("types", () => {
     assert.strictEqual(types.ARRAY, "array");
   });
 
+  it("has a DATE property set to 'date'", () => {
+    assert.strictEqual(types.DATE, "date");
+  });
+
   it("has an BOOLEAN property set to 'boolean'", () => {
     assert.strictEqual(types.BOOLEAN, "boolean");
   });
@@ -32,11 +36,14 @@ describe("types", () => {
     it("contains ARRAY", () => {
       assert(types.STRUCTURES.indexOf(types.ARRAY) !== -1);
     });
+    it("contains DATE", () => {
+      assert(types.STRUCTURES.indexOf(types.DATE) !== -1);
+    });
     it("contains OBJECT", () => {
       assert(types.STRUCTURES.indexOf(types.OBJECT) !== -1);
     });
-    it("has a length of 2", () => {
-      assert.equal(types.STRUCTURES.length, 2);
+    it("has a length of 3", () => {
+      assert.equal(types.STRUCTURES.length, 3);
     });
   });
 


### PR DESCRIPTION
Even though dates aren't technically defined in JSON, I think it is useful to include the raw values in the diff process since the diff is performed prior to serialization. The current object comparison doesn't seem to handle dates correctly.